### PR TITLE
Allow non-sync futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,10 @@ chrono = "0.4"
 cron = "0.12"
 thiserror = "1.0"
 crossbeam-channel = "0.5"
-tokio = { version = "1.25", optional = true , features = ["sync", "rt-multi-thread", "time", "macros"] }
+tokio = { version = "1.25", optional = true, features = ["sync", "rt-multi-thread", "time", "macros"] }
 futures = { version = "0.3.26", optional = true }
+
+[[example]]
+name = "async_simple"
+path = "examples/async_simple.rs"
+required-features = ["async"]

--- a/src/async_cron.rs
+++ b/src/async_cron.rs
@@ -53,7 +53,7 @@ where
     pub async fn add_fn<F, T>(&mut self, spec: &str, f: F) -> Result<usize>
     where
         F: 'static + Fn() -> T + Send + Sync,
-        T: 'static + Future<Output = ()> + Send + Sync,
+        T: 'static + Future<Output = ()> + Send,
     {
         let schedule = cron::Schedule::from_str(spec)?;
         self.schedule(schedule, f).await
@@ -184,7 +184,7 @@ where
     async fn schedule<F, T>(&mut self, schedule: cron::Schedule, f: F) -> Result<usize>
     where
         F: 'static + Fn() -> T + Send + Sync,
-        T: 'static + Future<Output = ()> + Send + Sync,
+        T: 'static + Future<Output = ()> + Send,
     {
         let next_id = self.next_id.fetch_add(1, Ordering::SeqCst);
 

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "async")]
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "async")]
 #[cfg(test)]
 mod tests {
+    use std::cell::UnsafeCell;
     use std::sync::Arc;
 
     use chrono::{FixedOffset, Local, TimeZone};
@@ -29,9 +30,14 @@ mod tests {
 
         cron.add_fn("* * * * * *", move || {
             let counter1 = Arc::clone(&counter1);
+
+            // use UnsafeCell to make sure we can still use non-Sync types
+            let mut inc: UnsafeCell<usize> = 1.into();
+
             async move {
                 let mut value = counter1.lock().await;
-                *value += 1;
+                let inc = *inc.get_mut();
+                *value += inc;
             }
         })
         .await


### PR DESCRIPTION
Futures don't have to be Sync. removing the Sync bound allows using non-Sync types (e.g. UnsafeCell) in the Future.

additionally, compile/run the async tests dependant on the "async" feature